### PR TITLE
fix: remove player icon

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -9,7 +9,6 @@ export class Player implements IPlayer {
   lives: number;
   kills: number;
   coords: ICoords;
-  icon: string;
   name: string;
   userId: string;
   constructor(protected game: ITankTacticsGame, data: PlayerWithCoords) {
@@ -19,7 +18,6 @@ export class Player implements IPlayer {
     this.lives = data.lives;
     this.kills = data.kills;
     this.coords = data.coords;
-    this.icon = data.icon;
     this.name = data.name;
     this.userId = data.userId;
     if (this.coords.x === -1) this.coords.x = Math.floor(Math.random() * this.game.boardWidth);

--- a/src/canvasCreation.ts
+++ b/src/canvasCreation.ts
@@ -1,4 +1,5 @@
 import { createCanvas, loadImage, Image } from 'canvas';
+import { client } from '.';
 import { TankTacticsGame } from './TankTactics';
 
 export async function gameToCanvas(game: TankTacticsGame) {
@@ -13,7 +14,13 @@ export async function gameToCanvas(game: TankTacticsGame) {
   const cellHeight = Math.floor(canvas.width / game.boardWidth);
 
   for await (const [, player] of game.players) {
-    if (!playerImages[player.id]) playerImages[player.id] = await loadImage(player.icon);
+    if (!playerImages[player.id]) {
+      const discordUser = await client.users.fetch(player.userId);
+      playerImages[player.id] = await loadImage(discordUser.displayAvatarURL({
+        format: 'png',
+        size: 32,
+      }));
+    }
   }
 
   const colors = [

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -57,10 +57,6 @@ export const executeCommand: Command<typeof commandData> = async ({ interaction,
         players: {
           create: [...members.map((player) => ({
             userId: player.user.id,
-            icon: player.user.displayAvatarURL({
-              format: 'png',
-              size: 32,
-            }),
             name: player.user.tag,
             points: 1,
             range: 2,

--- a/src/commands/playagain.ts
+++ b/src/commands/playagain.ts
@@ -53,7 +53,6 @@ export const executeCommand: Command<typeof commandData> = async ({ interaction,
         players: {
           create: [...game.players.map((player) => ({
             userId: player.userId,
-            icon: player.icon,
             name: player.name,
             points: 1,
             range: 2,

--- a/src/prisma/migrations/20210918204727_remove_user_icon/migration.sql
+++ b/src/prisma/migrations/20210918204727_remove_user_icon/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `icon` on the `Player` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Player" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gameId" TEXT,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "points" INTEGER NOT NULL,
+    "range" INTEGER NOT NULL,
+    "lives" INTEGER NOT NULL,
+    "kills" INTEGER NOT NULL,
+    "coordsId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    FOREIGN KEY ("gameId") REFERENCES "Game" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    FOREIGN KEY ("coordsId") REFERENCES "Coordinates" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Player" ("coordsId", "createdAt", "gameId", "id", "kills", "lives", "name", "points", "range", "updatedAt", "userId") SELECT "coordsId", "createdAt", "gameId", "id", "kills", "lives", "name", "points", "range", "updatedAt", "userId" FROM "Player";
+DROP TABLE "Player";
+ALTER TABLE "new_Player" RENAME TO "Player";
+CREATE UNIQUE INDEX "Player_coordsId_unique" ON "Player"("coordsId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -40,7 +40,6 @@ model Player {
   game      Game?       @relation(fields: [gameId], references: [id])
   gameId    String?
   userId    String
-  icon      String
   name      String
   points    Int
   range     Int

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,6 @@ export interface IPlayer {
   lives: number;
   kills: number;
   coords: ICoords;
-  icon: string;
   name: string;
   userId: string;
 


### PR DESCRIPTION
This PR removes the cached player icon.

Since the database schema was updated, the migrate script needs to be ran again.